### PR TITLE
Add HTTP_* headers into %env

### DIFF
--- a/examples/05-psgi-small.pl6
+++ b/examples/05-psgi-small.pl6
@@ -3,11 +3,11 @@ use HTTP::Server::Simple::PSGI;
 
 my $host = 'localhost';
 my $port = 8080;
-my $app = sub ($env) {
+my $app = sub (%env) {
     return [
       '200',
       [ 'Content-Type' => 'text/plain' ],
-      [ "Hello", "World\n\n", $env.perl ]
+      [ "Hello", "World\n\n", %env.perl ]
     ];
 }
 


### PR DESCRIPTION
PSGI apps need all the headers they can get. In particular,
things like cookies work best if the headers are passed to
the app. This code follows the behavior of Plack.
