### PR TITLE
Simplify .setup() method, make it more correct

### DIFF
--- a/examples/02-simple-small.pl6
+++ b/examples/02-simple-small.pl6
@@ -9,14 +9,12 @@ class Example::Simple::Small is HTTP::Server::Simple {
     has %!header;
     has $!path;
     has $!query_string;
+    method setup ( :$path, :$query_string, *%rest ) {
+        $!path = $path;
+        $!query_string = $query_string;
+    }
     method header ( $key, $value ) {
         %!header{$key} = $value;
-    }
-    method path ($path) {
-        $!path = $path;
-    }
-    method query_string ($query_string) {
-        $!query_string = $query_string;
     }
     # override the request handler of the base class
     method handle_request () {

--- a/lib/HTTP/Server/Simple.pm6
+++ b/lib/HTTP/Server/Simple.pm6
@@ -48,7 +48,6 @@ role HTTP::Server::Simple {
             unless self.valid_http_method($method) { self.bad_request; }
             my ( $path, $query-string ) = $uri.split('?',2);
             $query-string //= ''; # // confuses P5 syntax highlighters
-            self.headers( self.parse_headers() );
             self.setup(
                 :method($method), # rakudobug RT
                 protocol     => $protocol || 'HTTP/0.9',
@@ -60,6 +59,7 @@ role HTTP::Server::Simple {
                 peername     => 'NYI',
                 peeraddr     => 'NYI',
             );
+            self.headers( self.parse_headers() );
             self.post_setup_hook;
             my $res = self.handler;
             $!connection.close();
@@ -89,17 +89,6 @@ role HTTP::Server::Simple {
     }
     method setup ( :$method, :$protocol, :$request_uri, :$path,
         :$query_string, :$localport, :$peername, :$peeraddr, :$localname ) {
-        # The following list could probably be rewritten as a loop, but
-        # when that was tried it was much, much slower than doing it inline.
-        if self.can('method')       { $!method       = $method       }
-        if self.can('protocol')     { $!protocol     = $protocol     }
-        if self.can('request_uri')  { $!request_uri  = $request_uri  }
-        if self.can('path')         { $!path         = $path         }
-        if self.can('query_string') { $!query_string = $query_string }
-        if self.can('localname')    { $!localname    = $localname    }
-        if self.can('localport')    { $!localport    = $localport    }
-        if self.can('peername')     { $!peername     = $peername     }
-        if self.can('peeraddr')     { $!peeraddr     = $peeraddr     }
     }
     method headers (@headers) {
         for @headers -> $key, $value {


### PR DESCRIPTION
The .setup() method was too complicated, and relied on a misfeature of
Rakudo which confuses attributes and methods (using .can() to test for
attribute existence).  See:
    http://irclog.perlgeek.de/perl6/2011-07-11#i_4094525

Now, .setup() is simply a stub that's meant to be overridden, and the
subclass can handle that data appropriately.

Move the call to .headers() after the call to .setup(), to make
it easier to set up a request environment before processing the headers.

Also, fixed examples/02-simple-small.pl6, which had two methods which
were never called (replace them with a .setup() method instead).
