### PR TITLE
Fixes method implementation issue from latest Rakudo release.

### DIFF
--- a/lib/HTTP/Server/Simple.pm6
+++ b/lib/HTTP/Server/Simple.pm6
@@ -143,13 +143,13 @@ role HTTP::Server::Simple {
         $candidate_method eq any( <GET POST HEAD PUT DELETE> );
     }
     # Not Yet Implemented
-    method background ( *@arguments ) { ... }
-    method restart () { ... }
-    method stdio_handle () { ... }
-    method stdin_handle () { ... }
-    method stdout_handle () { ... }
+    method background ( *@arguments ) { <...> }
+    method restart () { <...> }
+    method stdio_handle () { <...> }
+    method stdin_handle () { <...> }
+    method stdout_handle () { <...> }
     method after_setup_listener () { }
-    method bad_request () { ... }
+    method bad_request () { <...> }
 }
 
 =begin pod


### PR DESCRIPTION
Throws the error "Method 'background' must be implemented by HTTP::Server::Simple because it is required by a role", as it does for each method using ... instead of <...>, *, or <*>.
