### PR TITLE
removed redundant(?) methods hash. gave warnings

### DIFF
--- a/lib/HTTP/Server/Simple.pm6
+++ b/lib/HTTP/Server/Simple.pm6
@@ -21,7 +21,6 @@ role HTTP::Server::Simple {
     }
 
     method new ( $port=8080 ) {
-        my %methods = self.^methods Z 1..*; # convert list to hash pairs
         self.bless( self.CREATE(), # self might also be a subclass
             port    => $port,
             host    => self.lookup_localhost,


### PR DESCRIPTION
Hey,

This line was emitting a warning:

```
Code object coerced to string (please use .gist or .perl to do that)  in method new at lib/HTTP/Server/Simple.pm6:24
```

I couldn't see `%methods` being used anywhere so I removed the line. 

Thanks
